### PR TITLE
Distinguish between Composer downloaded or error 

### DIFF
--- a/Console/Command/ComposerShell.php
+++ b/Console/Command/ComposerShell.php
@@ -167,7 +167,11 @@ class ComposerShell extends AppShell {
 		$version = @exec("php {$this->pharDir}composer.phar --version");
 
 		if (stripos($version, 'Composer') === false || stripos($version, 'version') === false) {
-			$this->out('<warning>Composer is not installed.</warning>');
+			if(file_exists("{$this->pharDir}composer.phar")) {
+				$this->out('<warning>Composer is installed, but there was an error executing it.</warning>');
+			} else {
+				$this->out('<warning>Composer is not installed.</warning>');
+			}
 
 			if (array_key_exists('yes', $this->params)) {
 				$this->_setup();


### PR DESCRIPTION
In _checkComposerPhar(), make error message distinguish between error executing composer.phar and if it exists at all.

On my host, phar was not added to suhosin whitelist, so composer.phar wouldn't run. cakephp-composer only said that Composer wasn't installed, but the error was actually that composer failed to run.
