### PR TITLE
added no-dev option to command-line options

### DIFF
--- a/Console/Command/ComposerShell.php
+++ b/Console/Command/ComposerShell.php
@@ -113,6 +113,7 @@ class ComposerShell extends AppShell {
 			'version' => array('short' => 'V'),
 			'ansi' => array(),
 			'no-ansi' => array(),
+			'no-dev' => array(),
 			'no-interaction' => array('short' => 'n'),
 			'profile' => array(),
 			'working-dir' => array('short' => 'd'),


### PR DESCRIPTION
Hello U-zyn,

thanks for this plugin, it really helps in my cake-projects.

On the deployment I always needed the "no-dev"-option. I couldn`t find a way to use this option without changing the plugin-code. Maybe my change was unnecessary. Anyway, maybe you would like to incorporate it into the plugin.

David
